### PR TITLE
Add cancellation support for sale items

### DIFF
--- a/docker/rabbitmq/init.sh
+++ b/docker/rabbitmq/init.sh
@@ -25,6 +25,11 @@ rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" \
 rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" \
     --host=localhost \
     --port=15672 \
+    declare queue name=sale.item.cancelled.queue durable=true
+    
+rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" \
+    --host=localhost \
+    --port=15672 \
     declare binding source=sale.events destination=sale.created.queue \
     destination_type=queue routing_key="sale.created"
 
@@ -39,3 +44,9 @@ rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" \
     --port=15672 \
     declare binding source=sale.events destination=sale.cancelled.queue \
     destination_type=queue routing_key="sale.cancelled"
+
+rabbitmqadmin -u "$RABBITMQ_DEFAULT_USER" -p "$RABBITMQ_DEFAULT_PASS" \
+    --host=localhost \
+    --port=15672 \
+    declare binding source=sale.events destination=sale.item.cancelled.queue \
+    destination_type=queue routing_key="sale.item.cancelled"

--- a/src/Ambev.DeveloperEvaluation.Application/EventHandlers/ItemCancelledEventHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/EventHandlers/ItemCancelledEventHandler.cs
@@ -1,0 +1,20 @@
+using Ambev.DeveloperEvaluation.Application.Interfaces;
+using Ambev.DeveloperEvaluation.Domain.Events;
+using Ambev.DeveloperEvaluation.Domain.SeedWork;
+
+namespace Ambev.DeveloperEvaluation.Application.EventHandlers;
+
+public class ItemCancelledEventHandler : IDomainEventHandler<ItemCancelledEvent>
+{
+    private readonly IMessageProducer _messageProducer;
+
+    public ItemCancelledEventHandler(IMessageProducer messageProducer)
+    {
+        _messageProducer = messageProducer;
+    }
+
+    public async Task HandleAsync(ItemCancelledEvent domainEvent, CancellationToken cancellationToken)
+    {
+        await _messageProducer.SendMessageAsync(domainEvent, cancellationToken);
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemCommand.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemCommand.cs
@@ -1,0 +1,9 @@
+using MediatR;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelItem;
+
+public class CancelItemCommand : IRequest<CancelItemResult>
+{
+    public Guid SaleId { get; set; }
+    public Guid ItemId { get; set; }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemCommandValidator.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemCommandValidator.cs
@@ -1,0 +1,23 @@
+using FluentValidation;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelItem;
+
+/// <summary>
+/// Validator for <see cref="CancelItemCommand"/> that defines validation rules for cancel a sale item.
+/// </summary>
+public class CancelItemCommandValidator : AbstractValidator<CancelItemCommand>
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CancelItemCommandValidator"/> with defined validation rules.
+    /// </summary>
+    public CancelItemCommandValidator()
+    {
+        RuleFor(x => x.SaleId)
+            .NotEmpty()
+            .WithMessage("SaleId is required");
+
+        RuleFor(x => x.ItemId)
+            .NotEmpty()
+            .WithMessage("ItemId is required");
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemHandler.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemHandler.cs
@@ -1,0 +1,64 @@
+using System.ComponentModel.DataAnnotations;
+using Ambev.DeveloperEvaluation.Application.Exceptions;
+using Ambev.DeveloperEvaluation.Application.Interfaces;
+using Ambev.DeveloperEvaluation.Domain.Events;
+using Ambev.DeveloperEvaluation.Domain.Exceptions;
+using Ambev.DeveloperEvaluation.Domain.Repositories;
+using AutoMapper;
+using MediatR;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelItem;
+
+public class CancelItemHandler : IRequestHandler<CancelItemCommand, CancelItemResult>
+{
+    private readonly ISaleRepository _saleRepository;
+    private readonly IMapper _mapper;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CancelItemHandler(ISaleRepository saleRepository, IMapper mapper, IUnitOfWork unitOfWork)
+    {
+        _saleRepository = saleRepository;
+        _mapper = mapper;
+        _unitOfWork = unitOfWork;
+    }
+
+    public async Task<CancelItemResult> Handle(CancelItemCommand command, CancellationToken cancellationToken)
+    {
+        var validator = new CancelItemCommandValidator();
+        var validationResult = await validator.ValidateAsync(command, cancellationToken);
+
+        if (!validationResult.IsValid)
+            throw new ValidationException(validationResult.Errors.ToString());
+
+        var sale = await _saleRepository.GetByIdAsync(command.SaleId, cancellationToken);
+        var item = sale.Items.FirstOrDefault(i => i.Id == command.ItemId);
+
+        if (item == null)
+            throw new NotFoundException($"Item with id {command.ItemId} not found in sale {command.SaleId}");
+
+        try
+        {
+            if (item.IsCancelled)
+                throw new EntityValidationException("Item is already cancelled");
+
+            item.Cancel();
+            await _saleRepository.UpdateAsync(sale, cancellationToken);
+
+            sale.RaiseEvent(new ItemCancelledEvent(sale, item));
+
+            await _unitOfWork.CommitAsync(cancellationToken);
+
+            return _mapper.Map<CancelItemResult>((sale, command.ItemId));
+        }
+        catch (EntityValidationException)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            throw;
+        }
+        catch (Exception)
+        {
+            await _unitOfWork.RollbackAsync(cancellationToken);
+            throw;
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemProfile.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemProfile.cs
@@ -1,0 +1,22 @@
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using AutoMapper;
+
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelItem;
+
+/// <summary>
+/// Profile for mapping between SaleItem entity and CancelItemResult
+/// </summary>
+public class CancelItemProfile : Profile
+{
+    /// <summary>
+    /// Initializes the mappings for CancelItem operation
+    /// </summary>
+    public CancelItemProfile()
+    {
+        CreateMap<(Sale sale, Guid itemId), CancelItemResult>()
+            .ForMember(dest => dest.SaleId, opt => opt.MapFrom(src => src.sale.Id))
+            .ForMember(dest => dest.ItemId, opt => opt.MapFrom(src => src.itemId))
+            .ForMember(dest => dest.CancelledAt, opt =>
+                opt.MapFrom(src => src.sale.Items.First(i => i.Id == src.itemId).CancelledAt!.Value));
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemResult.cs
+++ b/src/Ambev.DeveloperEvaluation.Application/Sales/CancelItem/CancelItemResult.cs
@@ -1,0 +1,8 @@
+namespace Ambev.DeveloperEvaluation.Application.Sales.CancelItem;
+
+public class CancelItemResult
+{
+    public Guid SaleId { get; set; }
+    public Guid ItemId { get; set; }
+    public DateTime CancelledAt { get; set; }
+}

--- a/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Entities/SaleItem.cs
@@ -40,6 +40,16 @@ public class SaleItem : BaseEntity
     public Guid SaleId { get; private set; }
 
     /// <summary>
+    ///  Indicates whether the sale item is cancelled.
+    /// </summary>
+    public bool IsCancelled { get; private set; }
+
+    /// <summary>
+    /// Date and time when the sale item was cancelled.
+    /// </summary>
+    public DateTime? CancelledAt { get; private set; }
+
+    /// <summary>
     /// Navigation property to the associated sale.
     /// </summary>
     public Sale Sale { get; set; } = new();
@@ -55,6 +65,7 @@ public class SaleItem : BaseEntity
         ProductId = productId;
         Quantity = quantity;
         UnitPrice = unitPrice;
+        IsCancelled = false;
         ApplyDiscount();
         CalculateTotal();
 
@@ -126,6 +137,19 @@ public class SaleItem : BaseEntity
     private void CalculateTotal() =>
         TotalValue = Quantity * UnitPrice * (1 - Discount);
 
+    /// <summary>
+    ///  Cancels the sale item.
+    /// </summary>
+    public void Cancel()
+    {
+        if (IsCancelled)
+            throw new EntityValidationException("Item is already cancelled");
+
+        IsCancelled = true;
+        CancelledAt = DateTime.UtcNow;
+
+        Validate();
+    }
 
     /// <summary>
     /// Validates the sale item.

--- a/src/Ambev.DeveloperEvaluation.Domain/Events/ItemCancelledEvent.cs
+++ b/src/Ambev.DeveloperEvaluation.Domain/Events/ItemCancelledEvent.cs
@@ -1,0 +1,16 @@
+using Ambev.DeveloperEvaluation.Domain.Entities;
+using Ambev.DeveloperEvaluation.Domain.SeedWork;
+
+namespace Ambev.DeveloperEvaluation.Domain.Events;
+
+public class ItemCancelledEvent : DomainEvent
+{
+    public SaleItem Item { get; }
+    public Sale Sale { get; }
+
+    public ItemCancelledEvent(Sale sale, SaleItem item)
+    {
+        Sale = sale;
+        Item = item;
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.IoC/ModuleInitializers/InfrastructureModuleInitializer.cs
+++ b/src/Ambev.DeveloperEvaluation.IoC/ModuleInitializers/InfrastructureModuleInitializer.cs
@@ -24,5 +24,6 @@ public class InfrastructureModuleInitializer : IModuleInitializer
         builder.Services.AddScoped<IDomainEventHandler<SaleCreatedEvent>, SaleCreatedEventHandler>();
         builder.Services.AddScoped<IDomainEventHandler<SaleModifiedEvent>, SaleModifiedEventHandler>();
         builder.Services.AddScoped<IDomainEventHandler<SaleCancelledEvent>, SaleCancelledEventHandler>();
+        builder.Services.AddScoped<IDomainEventHandler<ItemCancelledEvent>, ItemCancelledEventHandler>();
     }
 }

--- a/src/Ambev.DeveloperEvaluation.Messaging/Configuration/EventsMapping.cs
+++ b/src/Ambev.DeveloperEvaluation.Messaging/Configuration/EventsMapping.cs
@@ -10,7 +10,8 @@ internal static class EventsMapping
         { nameof(SaleModifiedEvent), "sale.modified" },
         {
             nameof(SaleCancelledEvent), "sale.cancelled"
-        }
+        },
+        { nameof(ItemCancelledEvent), "sale.item.cancelled" }
     };
 
     public static string GetRoutingKey<T>() => _routingKeys[typeof(T).Name];

--- a/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Mapping/SaleItemConfiguration.cs
@@ -17,6 +17,13 @@ public class SaleItemConfiguration : IEntityTypeConfiguration<SaleItem>
         builder.Property(i => i.UnitPrice).HasColumnType("decimal(18,2)");
         builder.Property(i => i.TotalValue).HasColumnType("decimal(18,2)");
 
+        builder.Property(x => x.IsCancelled)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(x => x.CancelledAt)
+            .IsRequired(false);
+
         builder.HasOne(i => i.Sale)
             .WithMany(i => i.Items);
     }

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250502232901_AddSaleItemCancellationFields.Designer.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250502232901_AddSaleItemCancellationFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Ambev.DeveloperEvaluation.ORM;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Ambev.DeveloperEvaluation.ORM.Migrations
 {
     [DbContext(typeof(SaleDbContext))]
-    partial class SaleContextModelSnapshot : ModelSnapshot
+    [Migration("20250502232901_AddSaleItemCancellationFields")]
+    partial class AddSaleItemCancellationFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250502232901_AddSaleItemCancellationFields.cs
+++ b/src/Ambev.DeveloperEvaluation.ORM/Migrations/20250502232901_AddSaleItemCancellationFields.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Ambev.DeveloperEvaluation.ORM.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddSaleItemCancellationFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CancelledAt",
+                table: "SaleItems",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsCancelled",
+                table: "SaleItems",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CancelledAt",
+                table: "SaleItems");
+
+            migrationBuilder.DropColumn(
+                name: "IsCancelled",
+                table: "SaleItems");
+        }
+    }
+}

--- a/src/Ambev.DeveloperEvaluation.WebApi/Ambev.DeveloperEvaluation.WebApi.Sales.http
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Ambev.DeveloperEvaluation.WebApi.Sales.http
@@ -177,3 +177,9 @@ Content-Type: application/json
 ### Cancel Sale
 PUT  http://localhost:5119/api/sales/28c97e4a-66db-438d-b3e2-05fe2b80f093/cancel
 Content-Type: application/json
+
+
+
+### Cancel Sale Item
+PUT http://localhost:5119/api/sales/878be5b6-b551-4e65-95c4-8d24dc2537a4/items/a577b40b-6767-4abc-9087-39812c0e5d1c/cancel
+Content-Type: application/json

--- a/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
+++ b/src/Ambev.DeveloperEvaluation.WebApi/Features/Sales/SalesController.cs
@@ -1,3 +1,4 @@
+using Ambev.DeveloperEvaluation.Application.Sales.CancelItem;
 using Ambev.DeveloperEvaluation.Application.Sales.CancelSale;
 using Ambev.DeveloperEvaluation.Application.Sales.CreateSale;
 using Ambev.DeveloperEvaluation.Application.Sales.UpdateSale;
@@ -132,6 +133,30 @@ public class SalesController : ControllerBase
         {
             Success = true,
             Message = "Sale cancelled successfully.",
+            Data = result
+        });
+    }
+
+    /// <summary>
+    /// Cancels a specific item in a sale.
+    /// </summary>
+    /// <param name="id">The sale ID.</param>
+    /// <param name="itemId">The item ID to cancel.</param>
+    /// <param name="cancellationToken">Cancellation token.</param>
+    /// <returns>The cancelled item details.</returns>
+    [HttpPut("{id:guid}/items/{itemId:guid}/cancel")]
+    [ProducesResponseType(typeof(ApiResponseWithData<CancelItemResult>), StatusCodes.Status200OK)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status400BadRequest)]
+    [ProducesResponseType(typeof(ApiResponse), StatusCodes.Status404NotFound)]
+    public async Task<IActionResult> CancelItem(Guid id, Guid itemId, CancellationToken cancellationToken)
+    {
+        var command = new CancelItemCommand { SaleId = id, ItemId = itemId };
+        var result = await _mediator.Send(command, cancellationToken);
+
+        return Ok(new ApiResponseWithData<CancelItemResult>
+        {
+            Success = true,
+            Message = "Item cancelled successfully.",
             Data = result
         });
     }


### PR DESCRIPTION
### Summary

This pull request adds cancellation support to sale items:

- Introduced new fields, `IsCancelled` and `CancelledAt`, to the `SaleItem` entity and corresponding database schema.
- Added domain logic, application-level commands, and API endpoint to handle sale item cancellations.
- Implemented event handling and configured RabbitMQ for `sale.item.cancelled` events, including new queue and routing. 

### Related Issues

_No associated issues._

### Checklist

- [ ] Unit tests added or updated.
- [ ] Documentation updated where applicable.